### PR TITLE
air injector tweak

### DIFF
--- a/code/ATMOSPHERICS/components/unary/outlet_injector.dm
+++ b/code/ATMOSPHERICS/components/unary/outlet_injector.dm
@@ -9,8 +9,8 @@
 	var/on = 0
 	var/injecting = 0
 
-	var/volume_rate = 50
-	var/max_rate=50
+	var/volume_rate = CELL_VOLUME //1 tile worth of air by default
+	var/max_rate= 4*CELL_VOLUME // 10000L
 
 	var/frequency = 0
 	var/datum/radio_frequency/radio_connection
@@ -53,7 +53,7 @@
 		return
 
 	if(air_contents.temperature > 0)
-		var/transfer_moles = (air_contents.return_pressure()) * volume_rate / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+		var/transfer_moles = (ONE_ATMOSPHERE) * volume_rate / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 
@@ -71,7 +71,7 @@
 	injecting = 1
 
 	if(air_contents.temperature > 0)
-		var/transfer_moles = (air_contents.return_pressure()) * volume_rate / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
+		var/transfer_moles = (ONE_ATMOSPHERE) * volume_rate / (air_contents.temperature * R_IDEAL_GAS_EQUATION)
 
 		var/datum/gas_mixture/removed = air_contents.remove(transfer_moles)
 
@@ -130,7 +130,7 @@
 
 	if("set_volume_rate" in signal.data)
 		var/number = text2num(signal.data["set_volume_rate"])
-		volume_rate = clamp(number, 0, air_contents.volume)
+		volume_rate = clamp(number, 0, max_rate)
 
 	if("status" in signal.data)
 		spawn(2)


### PR DESCRIPTION
<!--
Pull requests must be atomic. Change one set of related things at a time.
Test your changes. PRs that were not tested will not be accepted.

You can self-label your PR. See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->

## What this does
changes the air injectors to measure volume based on standard pressure, instead of the input gas pressure
increases the base pumping speed from 50L to 2500L (one tile's worth of air per tick)
increases the max pumping speed from 200L to 10000L

![image](https://user-images.githubusercontent.com/18052467/219066753-ad215258-e0af-4c03-8352-56b964a39a08.png)

![image](https://user-images.githubusercontent.com/18052467/219078546-3a9301b6-16e4-4ad1-88bd-1198c0764dc4.png)


## Why it's good
because i think so

## Changelog
<!-- See https://ss13.moe/wiki/index.php/Guide_to_Writing_a_Pull_Request -->
:cl:
 * tweak: unary air injectors now inject at a constant rate, regardless of pipe pressure
 
